### PR TITLE
Logging line return removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function createSlackMessage(data) {
   const statusUrl = data.url;
 
   const defaultText = `New post from ${username} on Mastodon!\n<${statusUrl}>`;
-  console.log(defaultText);
+  console.log(`Post: ${username} - ${statusUrl}.`);
 
   // The presence of a `media_attachments` array denotes an uploaded or pasted image. Mastodon handles
   // creating a link tag for these by default, and so they're included in the unfurled message in Slack,


### PR DESCRIPTION
I was lazily using the defaultText for logging but I failed to noticed a \n in it. 