### PR TITLE
Adding env var to specify endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ RUN yarn install
 
 COPY . . 
 
+ENV ENDPOINT public
+
 CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Create a `.env` file in your `tusky` directory that defines the following enviro
 ACCESS_TOKEN=mastodon-access-token
 MASTODON_URL=https://some-mastodon-instance.com
 SLACK_WEBHOOK_ENDPOINT=https://hook.some-slack-instance.com
+ENDPOINT=public/local
 ```
+
+Default ENDPOINT is public, which will show messages from remote instances. 
 
 Once you have your environment variables set up, run `docker-compose up -d` to start the container. This will start a `tusky` Docker container in the background. After that you're all set - tusky will listen for new Mastodon toots and post to your configured Slack endpoint to push the toots into your Slack instance.
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const EventSource = require("eventsource");
 
 const STREAMING_ENDPOINT = `${
   process.env.MASTODON_URL
-}/api/v1/streaming/public`;
+}/api/v1/streaming/${process.env.ENDPOINT}`;
 const URL = `${STREAMING_ENDPOINT}?access_token=${process.env.ACCESS_TOKEN}`;
 
 const source = new EventSource(URL);


### PR DESCRIPTION
ENDPOINT allows you to subscribe to local or local+federated endpoints per https://github.com/tootsuite/documentation/blob/master/Using-the-API/Streaming-API.md